### PR TITLE
Move preseed variable definition to defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,6 +83,8 @@ apt_debian_preseed_language: 'English'
 apt_debian_preseed_timezone: 'UTC'
 apt_debian_preseed_keyboardvariant: 'American English'
 apt_debian_preseed_mirror_country: 'United States'
-apt_debian_preseed_rootpw: 'debian'
 apt_debian_preseed_rootpw_length: '20'
+apt_debian_preseed_rootpw: "{{ lookup('password', secret + '/credentials/' + ansible_fqdn + '/debian_preseed/system/root/password encrypt=md5_crypt length=' + apt_debian_preseed_rootpw_length) }}"
+apt_debian_preseed_username: "{{ lookup('env','USER') }}"
+apt_debian_preseed_sshkey: "{{ lookup('pipe','ssh-add -L') }}"
 apt_debian_preseed_filesystem: 'ext4'

--- a/tasks/debian_preseed.yml
+++ b/tasks/debian_preseed.yml
@@ -1,24 +1,5 @@
 ---
 
-- name: Lookup system root password if secrets/ directory is defined
-  set_fact:
-    apt_debian_preseed_rootpw: "{{ lookup('password', secret + '/credentials/' + ansible_fqdn + '/debian_preseed/system/root/password encrypt=md5_crypt length=' + apt_debian_preseed_rootpw_length) }}"
-  when: secret is defined
-
-- name: Lookup current user for injection
-  set_fact:
-    apt_debian_preseed_username: "{{ lookup('env','USER') }}"
-
-- name: Check if SSH key of current user exists
-  local_action: stat path=~/.ssh/id_rsa.pub
-  sudo: False
-  register: apt_sshkey_idrsa
-
-- name: Lookup SSH public key of current user for injection
-  set_fact:
-    apt_debian_preseed_sshkey: "{{ lookup('file','~/.ssh/id_rsa.pub') }}"
-  when: apt_sshkey_idrsa is defined and apt_sshkey_idrsa.stat.exists == True
-
 - name: Create Debian Preseed directories
   file: path={{ item }} state=directory owner=root group=root mode=0755
   with_items:


### PR DESCRIPTION
Default root password lookup for Debian preseed script has been moved to
'defaults/main.yml' and should be easier to change or switch to static
password in inventory if necessary.

Default username and SSH public key lookups have also been moved there,
and SSH key is now sourced from `ssh-agent` instead of directly from
default file.
