### PR TITLE
Add default mirrors and sources for Raspbian, see issue #9.

### DIFF
--- a/vars/apt_default_mirrors_raspbian.yml
+++ b/vars/apt_default_mirrors_raspbian.yml
@@ -1,0 +1,5 @@
+---
+# List of default APT mirrors for Raspbian GNU/Linux distribution
+# More information: http://www.raspbian.org/RaspbianMirrors
+
+apt_default_mirrors: [ 'http://mirrordirector.raspbian.org/raspbian/' ]

--- a/vars/apt_default_sources_raspbian.yml
+++ b/vars/apt_default_sources_raspbian.yml
@@ -1,0 +1,8 @@
+---
+# List of default repositories for Raspbian GNU/Linux
+
+apt_default_sources:
+  - comment:  'Raspbian Main Repository'
+    mirrors:  [ 'http://mirrordirector.raspbian.org/raspbian/' ]
+    releases: [ '{{ apt_sources_release }}' ]
+    sections: [ 'main', 'contrib', 'non-free', 'rpi' ]


### PR DESCRIPTION
Because ansible is (as of today) not able to detect Raspbian,
you will still have to set:

```
  apt_default_sources_lookup: 'raspbian'
  apt_default_mirrors_lookup: 'raspbian'
```

in your host's `host_vars/xxx.yml`.
