### PR TITLE
Add `python-pip` to the apt-base-packages.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -99,7 +99,8 @@ apt_acng_allow: []
 apt_base_packages: [ 'ed', 'python', 'python-apt', 'lsb-release', 'make', 'sudo', 'gnupg-curl',
                      'git', 'wget', 'curl', 'rsync', 'netcat-openbsd', 'bridge-utils', 'vlan',
                      'openssh-server', 'openssh-blacklist', 'openssh-blacklist-extra', 'bsdutils',
-                     'python-pycurl', 'python-httplib2', 'apt-transport-https', 'acl' ]
+                     'python-pycurl', 'python-httplib2', 'apt-transport-https', 'acl',
+                     'python-pip']
 
 # List of additional "global" packages to install
 apt_packages: []


### PR DESCRIPTION
This is required to make the `pip` action in ansible work.