### PR TITLE
creating variables for -security and -backports

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,7 @@ apt_default_sources_lookup: '{{ ansible_distribution }}'
 # Linux distribution release to use for default APT repositories
 apt_sources_release: '{{ ansible_distribution_release.split("/")[0] }}'
 apt_sources_release_updates: '{{ apt_sources_release }}-updates'
+apt_sources_release_security: '{{ apt_sources_release }}-security'
 apt_sources_release_backports: '{{ apt_sources_release }}-backports'
 
 # List of releases to enable in default APT repositories

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,12 +39,14 @@ apt_default_sources_lookup: '{{ ansible_distribution }}'
 
 # Linux distribution release to use for default APT repositories
 apt_sources_release: '{{ ansible_distribution_release.split("/")[0] }}'
+apt_sources_release_updates: '{{ apt_sources_release }}-updates'
+apt_sources_release_backports: '{{ apt_sources_release }}-updates'
 
 # List of releases to enable in default APT repositories
 apt_sources_release_list:
   - '{{ apt_sources_release }}'
-  - '{{ apt_sources_release }}-updates'
-  - '{{ apt_sources_release }}-backports'
+  - '{{ apt_sources_release_updates }}'
+  - '{{ apt_sources_release_backports }}'
 
 # List of repository types to eanble for default APT repositories. To enable
 # source repositories, add 'deb-src' to the list.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,7 +40,7 @@ apt_default_sources_lookup: '{{ ansible_distribution }}'
 # Linux distribution release to use for default APT repositories
 apt_sources_release: '{{ ansible_distribution_release.split("/")[0] }}'
 apt_sources_release_updates: '{{ apt_sources_release }}-updates'
-apt_sources_release_backports: '{{ apt_sources_release }}-updates'
+apt_sources_release_backports: '{{ apt_sources_release }}-backports'
 
 # List of releases to enable in default APT repositories
 apt_sources_release_list:

--- a/tasks/install_conditional.yml
+++ b/tasks/install_conditional.yml
@@ -17,7 +17,7 @@
 # You should also probably install newer kernel
 # http://debian.distrosfaqs.org/debian-user/wheezy-irqbalance/
 - name: Install packages useful on SMP systems
-  apt: pkg={{ item }} default_release={{ apt_sources_release + '-backports' }} install_recommends=no state=latest update_cache=yes
+  apt: pkg={{ item }} default_release={{ apt_sources_release_backports }} install_recommends=no state=latest update_cache=yes
   with_items:
     - irqbalance
     #- linux-image-amd64

--- a/vars/apt_default_sources_ubuntu.yml
+++ b/vars/apt_default_sources_ubuntu.yml
@@ -4,7 +4,7 @@
 apt_default_sources:
   - comment:  'Ubuntu Security Repository'
     mirrors:  [ 'http://security.ubuntu.com/ubuntu' ]
-    releases: [ '{{ apt_sources_release }}-security' ]
+    releases: [ '{{ apt_sources_release_security }}' ]
     sections: [ 'main', 'restricted', 'universe', 'multiverse' ]
 
   - comment:  'Ubuntu Package Repositories'


### PR DESCRIPTION
I use mint, an ubuntu derivate. It does not have backports of qiana, so I needed a way around the hardcoded -backports.
Now I set the backports variable to my release, qiana, and it works.