### PR TITLE
Disable Ubuntu partner and extras repositories

### DIFF
--- a/vars/apt_default_sources_ubuntu.yml
+++ b/vars/apt_default_sources_ubuntu.yml
@@ -11,13 +11,13 @@ apt_default_sources:
     releases: '{{ apt_sources_release_list }}'
     sections: [ 'main', 'restricted', 'universe', 'multiverse' ]
 
-  - comment:  'Ubuntu Partner Repository'
-    mirrors:  [ 'http://archive.canonical.com/ubuntu' ]
-    releases: [ '{{ apt_sources_release }}' ]
-    sections: [ 'partner' ]
+  #- comment:  'Ubuntu Partner Repository'
+  #  mirrors:  [ 'http://archive.canonical.com/ubuntu' ]
+  #  releases: [ '{{ apt_sources_release }}' ]
+  #  sections: [ 'partner' ]
 
-  - comment:  'Ubuntu Extras Repository'
-    mirrors:  [ 'http://extras.ubuntu.com/ubuntu' ]
-    releases: [ '{{ apt_sources_release }}' ]
-    sections: [ 'main' ]
+  #- comment:  'Ubuntu Extras Repository'
+  #  mirrors:  [ 'http://extras.ubuntu.com/ubuntu' ]
+  #  releases: [ '{{ apt_sources_release }}' ]
+  #  sections: [ 'main' ]
 


### PR DESCRIPTION
These repositories are creating problems on different installations,
disabled for the time being.