### PR TITLE
Change default Ubuntu mirror

### DIFF
--- a/vars/apt_default_mirrors_ubuntu.yml
+++ b/vars/apt_default_mirrors_ubuntu.yml
@@ -1,5 +1,5 @@
 ---
 
 # List of default APT mirrors for Ubuntu Linux distribution
-apt_default_mirrors: [ 'mirror://mirrors.ubuntu.com/mirrors.txt' ]
+apt_default_mirrors: [ 'http://archive.ubuntu.com/ubuntu' ]
 


### PR DESCRIPTION
The 'mirrors://' method suggested in Ubuntu documentation for providing
localized APT mirrors is not reliable. I'm switching to
'archive.ubuntu.com' mirror until some other alternative is available.