### PR TITLE
Remove sources.list cleanup task

### DIFF
--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -1,11 +1,5 @@
 ---
 
-  # This is a temporary task
-- name: Remove old version of package sources if present
-  file:
-    path: '/etc/apt/sources.list.d/00_ansible_{{ ansible_distribution | lower }}_sources.list'
-    state: 'absent'
-
 - name: Configure APT
   template:
     src: '{{ item }}.j2'


### PR DESCRIPTION
This task was needed during the transition from old source lists in
'/etc/apt/sources.list.d/' into one unified sources.list file. It's not
required anymore.