### PR TITLE
Switch default Debian mirror to http.debian.net

### DIFF
--- a/vars/apt_default_mirrors_debian.yml
+++ b/vars/apt_default_mirrors_debian.yml
@@ -2,5 +2,5 @@
 
 # List of default APT mirrors for Debian GNU/Linux distribution
 # More information: https://wiki.debian.org/DebianGeoMirror
-apt_default_mirrors: [ 'http://cdn.debian.net/debian' ]
+apt_default_mirrors: [ 'http://http.debian.net/debian' ]
 


### PR DESCRIPTION
According to https://wiki.debian.org/DebianGeoMirror cdn.debian.net has
been deprecated, and this change is long overdue.