### PR TITLE
Rearrange APT tasks to avoid apt_repository issue

### DIFF
--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -39,6 +39,28 @@
     apt_mirrors_combined: '{{ apt_mirrors + apt_default_mirrors | default([]) }}'
     apt_sources_combined: '{{ apt_default_sources | default([]) + apt_sources + apt_sources_delayed_enabled | default([]) }}'
 
+- name: Configure custom APT keys
+  apt_key:
+    data: '{{ item.data   | default(omit) }}'
+    file: '{{ item.file   | default(omit) }}'
+    id:   '{{ item.id     | default(omit) }}'
+    keyring: '{{ item.keyring | default(omit) }}'
+    keyserver: '{{ item.keyserver | default(omit) }}'
+    state: '{{ item.state | default("present") }}'
+    url: '{{ item.url | default(omit) }}'
+  with_items: apt_keys_combined
+  when: (item.url is defined or item.data is defined or item.id is defined or item.file is defined and
+         (item.state is undefined or item.state is defined))
+
+- name: Configure custom APT repositories
+  apt_repository:
+    repo: '{{ item.repo }}'
+    state: '{{ item.state | default("present") }}'
+    update_cache: False
+  with_items: apt_repositories_combined
+  when: ((item.repo is defined and item.repo) and
+         (item.state is undefined or item.state is defined))
+
 - name: Divert original /etc/apt/sources.list
   command: dpkg-divert --quiet --local --divert /etc/apt/sources.list.dpkg-divert --rename /etc/apt/sources.list
            creates=/etc/apt/sources.list.dpkg-divert
@@ -62,28 +84,6 @@
   command: dpkg-divert --quiet --local --rename --remove /etc/apt/sources.list
            removes=/etc/apt/sources.list.dpkg-divert
   when: not apt_sources_combined
-
-- name: Configure custom APT keys
-  apt_key:
-    data: '{{ item.data   | default(omit) }}'
-    file: '{{ item.file   | default(omit) }}'
-    id:   '{{ item.id     | default(omit) }}'
-    keyring: '{{ item.keyring | default(omit) }}'
-    keyserver: '{{ item.keyserver | default(omit) }}'
-    state: '{{ item.state | default("present") }}'
-    url: '{{ item.url | default(omit) }}'
-  with_items: apt_keys_combined
-  when: (item.url is defined or item.data is defined or item.id is defined or item.file is defined and
-         (item.state is undefined or item.state is defined))
-
-- name: Configure custom APT repositories
-  apt_repository:
-    repo: '{{ item.repo }}'
-    state: '{{ item.state | default("present") }}'
-    update_cache: False
-  with_items: apt_repositories_combined
-  when: ((item.repo is defined and item.repo) and
-         (item.state is undefined or item.state is defined))
 
 - name: Update package lists
   apt: update_cache=yes


### PR DESCRIPTION
'apt_repository' rewrites /etc/apt/sources.list when adding or removing
APT repositories. This change rearranges the task list so that Ansible
can recreate the previous version of main sources.list.