### PR TITLE
Disable nginx and ferm dependencies in debops.apt

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,18 +19,18 @@ dependencies:
         by_role: 'debops.apt'
 
 
-  - role: debops.etc_services
-    when: (apt is defined and apt) and (apt != True and apt == ansible_fqdn)
+  #- role: debops.etc_services
+  #  when: (apt is defined and apt) and (apt != True and apt == ansible_fqdn)
 
-  - role: debops.ferm
-    when: (apt is defined and apt) and (apt != True and apt == ansible_fqdn)
+  #- role: debops.ferm
+  #  when: (apt is defined and apt) and (apt != True and apt == ansible_fqdn)
 
-  - role: debops.nginx
-    nginx_servers:
-      - '{{ apt_debian_preseed_nginx.default }}'
-      - '{{ apt_debian_preseed_nginx.destroy }}'
-    when: (apt is defined and apt) and (apt != True and apt == ansible_fqdn)
-    tags: nginx
+  #- role: debops.nginx
+  #  nginx_servers:
+  #    - '{{ apt_debian_preseed_nginx.default }}'
+  #    - '{{ apt_debian_preseed_nginx.destroy }}'
+  #  when: (apt is defined and apt) and (apt != True and apt == ansible_fqdn)
+  #  tags: nginx
 
 
 galaxy_info:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,8 +19,8 @@ dependencies:
         by_role: 'debops.apt'
 
 
-  #- role: debops.etc_services
-  #  when: (apt is defined and apt) and (apt != True and apt == ansible_fqdn)
+  - role: debops.etc_services
+    when: (apt is defined and apt) and (apt != True and apt == ansible_fqdn)
 
   #- role: debops.ferm
   #  when: (apt is defined and apt) and (apt != True and apt == ansible_fqdn)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,8 +19,8 @@ dependencies:
         by_role: 'debops.apt'
 
 
-  - role: debops.etc_services
-    when: (apt is defined and apt) and (apt != True and apt == ansible_fqdn)
+  #- role: debops.etc_services
+  #  when: (apt is defined and apt) and (apt != True and apt == ansible_fqdn)
 
   #- role: debops.ferm
   #  when: (apt is defined and apt) and (apt != True and apt == ansible_fqdn)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,11 @@
 
 #- acng Server
 
-- include: configure_acng_server.yml
-  when: apt != True and apt == ansible_fqdn
+#- include: configure_acng_server.yml
+#  when: apt != True and apt == ansible_fqdn
 
-- include: debian_preseed.yml
-  when: apt != True and apt == ansible_fqdn
+#- include: debian_preseed.yml
+#  when: apt != True and apt == ansible_fqdn
 
 #- acng Client
 


### PR DESCRIPTION
debops.ferm role, which debops.postfix depends on, has some weird
interaction with debops.nginx role which is used in debops.apt role.
This interfaction results in ferm restart handler not firing properly
when notified by Postfix role, only skipped. Which resulted in this fix:

https://github.com/debops/ansible-postfix/commit/0ef60f524ad045c3197caee1b40721be7740e35c

Now to reverse that, I decided to disable nginx and ferm in debops.apt
role. It is used by Debian Preseed setup, which should be moved to
a separate role by now anyway, so this will force me to create that role
soon. ferm is used by 'apt-cacher-ng' which also should be moved to
a separate role.

If either of those are needed, the dependencies can be temporarily
enabled to configure needed services and then disabled again.