### PR TITLE
Remove 'openssh-blacklist' packages from base list

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -147,9 +147,8 @@ apt_acng_allow: []
 # This list will be included in Debian Preseed configuration
 apt_base_packages: [ 'ed', 'python', 'python-apt', 'lsb-release', 'make', 'sudo', 'gnupg-curl',
                      'git', 'wget', 'curl', 'rsync', 'netcat-openbsd', 'bridge-utils', 'vlan',
-                     'openssh-server', 'openssh-blacklist', 'openssh-blacklist-extra', 'bsdutils',
-                     'python-pycurl', 'python-httplib2', 'apt-transport-https', 'acl',
-                     'python-pip']
+                     'openssh-server', 'bsdutils', 'python-pycurl', 'python-httplib2',
+                     'apt-transport-https', 'acl', 'python-pip' ]
 
 # List of additional "global" packages to install
 apt_packages: []


### PR DESCRIPTION
'openssh-blacklist' and 'openssh-blacklist-extra' are removed from
Debian Jessie release. To keep forward compatibility they are removed
from the list of base packages. If needed on Wheezy, you can install
them using 'apt_packages' list.

Fixes #31