### PR TITLE
Changed apt_unattended_upgrades_minimal_steps to False by default.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -125,6 +125,12 @@ apt_unattended_upgrades_blacklist: [ 'vim', 'libc6' ]
 # If False, send mail notifications only on errors
 apt_unattended_upgrades_notify_always: True
 
+# If True, split the upgrade into the smallest possible chunks so that
+# they can be interrupted with SIGUSR1. This makes the upgrade
+# a bit slower but it has the benefit that shutdown while a upgrade
+# is running is possible (with a small delay)
+apt_unattended_upgrades_minimal_steps: False
+
 # Automatically remove unused dependencies
 apt_unattended_upgrades_autoremove: True
 

--- a/templates/etc/apt/apt.conf.d/55unattended-upgrades.conf.j2
+++ b/templates/etc/apt/apt.conf.d/55unattended-upgrades.conf.j2
@@ -13,7 +13,11 @@ Unattended-Upgrade::Package-Blacklist {
 // they can be interrupted with SIGUSR1. This makes the upgrade
 // a bit slower but it has the benefit that shutdown while a upgrade
 // is running is possible (with a small delay)
+{% if apt_unattended_upgrades_minimal_steps is defined and apt_unattended_upgrades_minimal_steps %}
 Unattended-Upgrade::MinimalSteps "true";
+{% else %}
+Unattended-Upgrade::MinimalSteps "false";
+{% endif %}
 
 // Send email to this address for problems or packages upgrades
 // If empty or unset then no email is sent, make sure that you


### PR DESCRIPTION
* Ansible is mostly used to manage servers and upgrades on servers are
  not too often interrupted.

What do you think? Anythink I overlooked?

The thing is that minimal_steps runs apt for each package upgrade which is slow.