### PR TITLE
Added apt_default_sources_sections for flexibility and to avoid redundancy.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 # Manage APT package manager
 #
-# Set to FQDN of a host to specify it as host for apt-cacher-ng (a server apt proxy).
+# Set to FQDN of a host to specify it as host for apt-cacher-ng (an apt proxy server).
 # (This proxy will be used by all other hosts).
 # Set to False to disable the usage of a proxy.
 apt: True

--- a/vars/apt_default_sources_debian.yml
+++ b/vars/apt_default_sources_debian.yml
@@ -1,13 +1,21 @@
 ---
 
+# Can not changed directly. To change it define apt_default_sources in your
+# inventory variables (same as below).
+# Then you can change the apt_default_sources_sections directly.
+apt_default_sources_sections:
+  - 'main'
+  - 'contrib'
+  - 'non-free'
+
 # List of default repositories for Debian GNU/Linux
 apt_default_sources:
   - comment:  'Debian Security Repository'
     mirrors:  [ 'http://security.debian.org/' ]
     releases: [ '{{ apt_sources_release }}/updates' ]
-    sections: [ 'main', 'contrib', 'non-free' ]
+    sections: '{{ apt_default_sources_sections }}'
 
   - comment:  'Debian Package Repositories'
     releases: '{{ apt_sources_release_list }}'
-    sections: [ 'main', 'contrib', 'non-free' ]
+    sections: '{{ apt_default_sources_sections }}'
 

--- a/vars/apt_default_sources_raspbian.yml
+++ b/vars/apt_default_sources_raspbian.yml
@@ -1,8 +1,17 @@
 ---
-# List of default repositories for Raspbian GNU/Linux
 
+# Can not changed directly. To change it define apt_default_sources in your
+# inventory variables (same as below).
+# Then you can change the apt_default_sources_sections directly.
+apt_default_sources_sections:
+  - 'main'
+  - 'contrib'
+  - 'non-free'
+  - 'rpi'
+
+# List of default repositories for Raspbian GNU/Linux
 apt_default_sources:
   - comment:  'Raspbian Main Repository'
     mirrors:  [ 'http://mirrordirector.raspbian.org/raspbian/' ]
     releases: [ '{{ apt_sources_release }}' ]
-    sections: [ 'main', 'contrib', 'non-free', 'rpi' ]
+    sections: '{{ apt_default_sources_sections }}'

--- a/vars/apt_default_sources_ubuntu.yml
+++ b/vars/apt_default_sources_ubuntu.yml
@@ -1,15 +1,24 @@
 ---
 
+# Can not changed directly. To change it define apt_default_sources in your
+# inventory variables (same as below).
+# Then you can change the apt_default_sources_sections directly.
+apt_default_sources_sections:
+  - 'main'
+  - 'restricted'
+  - 'universe'
+  - 'multiverse'
+
 # List of default repositories for Ubuntu Linux distribution
 apt_default_sources:
   - comment:  'Ubuntu Security Repository'
     mirrors:  [ 'http://security.ubuntu.com/ubuntu' ]
     releases: [ '{{ apt_sources_release_security }}' ]
-    sections: [ 'main', 'restricted', 'universe', 'multiverse' ]
+    sections: '{{ apt_default_sources_sections }}'
 
   - comment:  'Ubuntu Package Repositories'
     releases: '{{ apt_sources_release_list }}'
-    sections: [ 'main', 'restricted', 'universe', 'multiverse' ]
+    sections: '{{ apt_default_sources_sections }}'
 
   #- comment:  'Ubuntu Partner Repository'
   #  mirrors:  [ 'http://archive.canonical.com/ubuntu' ]


### PR DESCRIPTION
Usage example:

```YAML
- name: Group hosts by distribution
  group_by:
    key: 'distribution_{{ ansible_distribution }}'
  changed_when: False
```

group_vars/distribution_Debian:
```YAML

apt_default_sources_sections:
  - 'main'

apt_default_sources:
  - comment:  'Debian Security Repository'
    mirrors:  [ 'http://security.debian.org/' ]
    releases: [ '{{ apt_sources_release }}/updates' ]
    sections: '{{ apt_default_sources_sections }}'

  - comment:  'Debian Package Repositories'
    releases: '{{ apt_sources_release_list }}'
    sections: '{{ apt_default_sources_sections }}'
```

host_vars/host.example.com:
```YAML
apt_default_sources_sections:
  - 'main'

  ## Virtualbox
  - 'contrib'

  ## Firmware
  - 'non-free'
```