### PR TITLE
Added `apt_remove_default_configuration` option which defaults to true.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,3 +14,5 @@ v0.1.0
 - Switch the default Debian mirror to new official redirector at
   ``http://httpredir.debian.org/``. [drybjed]
 
+- Added ``apt_remove_default_configuration`` option which defaults to true.
+  This ensures that ``/etc/apt/apt.conf`` is absent. [ypid]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -152,6 +152,15 @@ apt_unattended_upgrades_autoremove: True
 
 # ---- Other ----
 
+# .. envvar:: apt_remove_default_configuration
+#
+# Ensure that ``/etc/apt/apt.conf`` is absent.
+# This file might contain APT proxy or other settings which overwrite options
+# set by ``debops.apt`` if present.
+# Thus the default is to ensure that this file is absent.
+apt_remove_default_configuration: True
+
+
 # Update APT cache early in the playbook if it's older than 24h
 # Set to False to disable update (useful when changing APT mirrors)
 apt_update_cache_early: '{{ (60 * 60 * 24) }}'

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -11,6 +11,14 @@
     - 'etc/apt/apt.conf.d/25no-recommends.conf'
     - 'etc/apt/apt.conf.d/70aptitude'
 
+- name: Ensure that APT default configuration is absent
+  file:
+    path: '{{ item }}'
+    state: 'absent'
+  when: apt_remove_default_configuration|d()
+  with_items:
+    - '/etc/apt/apt.conf'
+
 - name: Load default APT mirrors configuration
   include_vars: '{{ item }}'
   with_first_found:


### PR DESCRIPTION
This ensures that `/etc/apt/apt.conf` is absent which might be
configured by installing Debian manually and setting a proxy during
installation.