### PR TITLE
Use backported apt-cacher-ng on Debian Jessie.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,3 +16,5 @@ v0.1.0
 
 - Added ``apt_remove_default_configuration`` option which defaults to true.
   This ensures that ``/etc/apt/apt.conf`` is absent. [ypid]
+
+- Use backported apt-cacher-ng on Debian Jessie. [ypid]

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,6 +18,11 @@ dependencies:
         reason:  'Issues in wheezy package - http://debian.distrosfaqs.org/debian-user/wheezy-irqbalance/'
         by_role: 'debops.apt'
 
+      - package: 'apt-cacher-ng'
+        backports: [ 'jessie' ]
+        reason:  'http://httpredir.debian.org/debian is not included in the deb_mirrors.gz file of apt-cacher-ng as of 0.8.0-3 (latest in Debian Jessie). This can results in unnecessary resource (bandwidth, storage) usage.'
+        by_role: 'debops.apt'
+
 
   #- role: debops.etc_services
   #  when: (apt is defined and apt) and (apt != True and apt == ansible_fqdn)


### PR DESCRIPTION
http://httpredir.debian.org/debian is not included in the deb_mirrors.gz file of apt-cacher-ng as of 0.8.0-3 (latest in Debian Jessie).
This can results in unnecessary resource (bandwidth, storage) usage.

Even after [two point releases](https://wiki.debian.org/DebianJessie#Release_and_updates) `apt-cacher-ng` has not been updated in
Jessie.

See also:
https://github.com/debops/ansible-apt/commit/5a9c5917d0a97bdf4ce1f38570b25d9596794bec#commitcomment-11182490