### PR TITLE
fix apt_unattended_upgrades_repositories add ansible_distribution №3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -155,7 +155,8 @@ apt_unattended_upgrades_autoremove: True
 #
 # The list of repositories from which you can automatically update
 apt_unattended_upgrades_repositories:
-    - "origin={{ ansible_distribution }},codename={{ apt_sources_release }},label={{ ansible_distribution }}-Security"
+    - "{%if ansible_distribution = 'Debian' %} origin={{ ansible_distribution }},codename={{ apt_sources_release }},label=Debian-Security {% endif %}"
+    - "{%if ansible_distribution = 'Ubuntu' %} origin={{ ansible_distribution }},codename={{ apt_sources_release }},archive={{ apt_sources_release_security }} {% endif %}"
 
 # ---- Other ----
 


### PR DESCRIPTION
I looked at the log in "unattended_upgrades -d" on ubuntu.
Properly should somehow be so.