### PR TITLE
Add support for apt_repository file mode

### DIFF
--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -98,6 +98,7 @@
   apt_repository:
     repo: '{{ item.repo }}'
     state: '{{ item.state | default("present") }}'
+    mode: '{{ item.mode | default("420") }}'
     update_cache: False
   with_items: '{{ apt__repositories_combined }}'
   when: ((item.repo is defined and item.repo) and

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -98,7 +98,7 @@
   apt_repository:
     repo: '{{ item.repo }}'
     state: '{{ item.state | default("present") }}'
-    mode: '{{ item.mode | default("420") }}'
+    mode: '{{ item.mode | default(omit) }}'
     update_cache: False
   with_items: '{{ apt__repositories_combined }}'
   when: ((item.repo is defined and item.repo) and


### PR DESCRIPTION
The apt_repository module has an unusual default file mode (420) for entries to ../sources.list.d/*. Setting files to 420 actually causes exceptions in Ubuntu's package manager interface.

While leaving the default setting as 420, it would be very nice to be able to override.