### PR TITLE
Configure http and https proxy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Added
 `debops.apt v0.2.0`_ - 2016-07-14
 ---------------------------------
 
-.. _debops.apt v0.2.0 https://github.com/debops/ansible-apt/compare/v0.1.0...v0.2.0
+.. _debops.apt v0.2.0: https://github.com/debops/ansible-apt/compare/v0.1.0...v0.2.0
 
 - Remove support for :program:`apt-cacher-ng`. The new role ``debops.apt_cacher_ng``
   handles this now. The overloaded :command:`apt` variable as been split into
@@ -63,7 +63,7 @@ Added
 `debops.apt v0.1.0`_ - 2016-05-26
 ---------------------------------
 
-.. _debops.apt v0.1.0 https://github.com/debops/ansible-apt/compare/v0.1.0...v0.2.0
+.. _debops.apt v0.1.0: https://github.com/debops/ansible-apt/compare/v0.1.0...v0.2.0
 
 Added
 ~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,8 +19,7 @@ Added
 ~~~~~
 
 - Added support for both http and https repositories in case of internet proxy.
-  Moved apt__proxy_url to :any:`apt__http_proxy_url` and 
-  :any:`added apt__https_proxy_url`.
+  Moved apt__proxy_url to :any:`apt__http_proxy_url` and added :any:`apt__https_proxy_url`.
 
 `debops.apt v0.2.0`_ - 2016-07-14
 ---------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,30 @@
+.. _apt__ref_changelog:
+
 Changelog
 =========
 
-v0.2.0
-------
+**debops.apt**
 
-*Released: 2016-05-26*
+This project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`_
+and `human-readable changelog <http://keepachangelog.com/>`_.
+
+The current role maintainer is drybjed.
+
+`debops.apt master`_ - unreleased
+---------------------------------
+
+.. _debops.apt master: https://github.com/debops/ansible-apt/compare/v0.2.0...master
+
+Added
+~~~~~
+
+- Added support for both http and https repositories in case of internet proxy.
+  Moved apt__proxy_url to apt__http_proxy_url and added apt__https_proxy_url.
+
+`debops.apt v0.2.0`_ - 2016-07-14
+---------------------------------
+
+.. _debops.apt master: https://github.com/debops/ansible-apt/compare/v0.1.0...v0.2.0
 
 - Remove support for :program:`apt-cacher-ng`. The new role ``debops.apt_cacher_ng``
   handles this now. The overloaded :command:`apt` variable as been split into
@@ -40,18 +60,20 @@ v0.2.0
 - Clean up package lists and remove unused tasks. The functionality has been
   moved to the ``debops.apt_install`` role. [drybjed]
 
+`debops.apt v0.1.0`_ - 2016-05-26
+---------------------------------
+
+.. _debops.apt master: https://github.com/debops/ansible-apt/compare/v0.1.0...v0.2.0
 v0.1.0
 ------
 
-*Released: 2016-05-26*
+Added
+~~~~~
 
 - Add Changelog. [drybjed]
 
 - Support "stacked inventory variables" for APT sources, repositories, keys and
   lists of mirrors. [drybjed]
-
-- Switch the default Debian mirror to new official redirector at
-  http://httpredir.debian.org/. [drybjed]
 
 - Added :any:`apt__remove_default_configuration` option which defaults to true.
   This ensures that :file:`/etc/apt/apt.conf` is absent. [ypid]
@@ -60,6 +82,12 @@ v0.1.0
 
 - Allow to modify APT sections without defining ``apt__default_sources`` by
   using the added ``apt__sources_sections`` variable. [ypid]
+
+Changed
+~~~~~~~
+
+- Switch the default Debian mirror to new official redirector at
+  http://httpredir.debian.org/. [drybjed]
 
 - Remove support for ``unattended-upgrades``. The new role
   ``debops.unattended_upgrades`` handles this now. The ``debops.apt`` role will

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Added
 `debops.apt v0.2.0`_ - 2016-07-14
 ---------------------------------
 
-.. _debops.apt master: https://github.com/debops/ansible-apt/compare/v0.1.0...v0.2.0
+.. _debops.apt v0.2.0 https://github.com/debops/ansible-apt/compare/v0.1.0...v0.2.0
 
 - Remove support for :program:`apt-cacher-ng`. The new role ``debops.apt_cacher_ng``
   handles this now. The overloaded :command:`apt` variable as been split into
@@ -63,7 +63,7 @@ Added
 `debops.apt v0.1.0`_ - 2016-05-26
 ---------------------------------
 
-.. _debops.apt master: https://github.com/debops/ansible-apt/compare/v0.1.0...v0.2.0
+.. _debops.apt v0.1.0 https://github.com/debops/ansible-apt/compare/v0.1.0...v0.2.0
 v0.1.0
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,8 @@ Added
 ~~~~~
 
 - Added support for both http and https repositories in case of internet proxy.
-  Moved apt__proxy_url to apt__http_proxy_url and added apt__https_proxy_url.
+  Moved apt__proxy_url to :any:`apt__http_proxy_url` and 
+  :any:`added apt__https_proxy_url`.
 
 `debops.apt v0.2.0`_ - 2016-07-14
 ---------------------------------
@@ -28,7 +29,7 @@ Added
 
 - Remove support for :program:`apt-cacher-ng`. The new role ``debops.apt_cacher_ng``
   handles this now. The overloaded :command:`apt` variable as been split into
-  :any:`apt__enabled` and :any:`apt__proxy`. [ypid]
+  :any:`apt__enabled` and apt__proxy. [ypid]
 
 - Added :any:`apt__proxy_bypass_for_bugs_debian_org` which you can enable if you
   hit a problem with a proxy server not allowing access to

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,8 +64,6 @@ Added
 ---------------------------------
 
 .. _debops.apt v0.1.0 https://github.com/debops/ansible-apt/compare/v0.1.0...v0.2.0
-v0.1.0
-------
 
 Added
 ~~~~~

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -1,0 +1,23 @@
+.. _apt__ref_upgrade_nodes:
+
+Upgrade notes
+=============
+
+The upgrade notes only describe necessary changes that you might need to make
+to your setup in order to use a new role release. Refer to the
+:ref:`apt__ref_changelog` for more details about what has changed.
+
+From v0.2.0 to v0.3.0
+---------------------
+
+The variable apt__proxy_url is split into two variables to support both http
+and https repositories when a proxy is used: apt__http_proxy_url and 
+apt__https_proxy_url.
+This script can come in handy to convert apt__proxy_url into the new variables:
+
+.. literalinclude:: scripts/upgrade-from-v0.2.x-to-v0.3.x
+   :language: shell
+
+The script is bundled with this role under
+:file:`docs/scripts/upgrade-from-v0.2.x-to-v0.3.x` and can be invoked from
+there.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,22 +67,29 @@ apt__update_notification_packages:
 #   Proxy settings
 # ------------------
 
-# .. envvar:: apt__proxy
+# .. envvar:: apt__http_proxy_url
 #
 # This variable allows you to define a software repository proxy which should
 # be used by specifying the URL of the proxy server.
 #
 # Examples::
 #
-#    apt__proxy_url: 'http://software-cache.example.org:3142/'
-#
-#    ## or
-#
-#    apt__proxy_url: 'https://software-cache.example.org:3142/'
+#    apt__http_proxy_url: 'http://software-cache.example.org:3142/'
 #
 # The default is to not use a proxy server and connect directly to the repository servers.
-apt__proxy_url: ''
+apt__http_proxy_url: ''
 
+# .. envvar:: apt__https_proxy_url
+#
+# This variable allows you to define a software repository proxy which should
+# be used by specifying the URL of the proxy server.
+#
+# Examples::
+#
+#    apt__https_proxy_url: 'http://software-cache.example.org:3142/'
+#
+# The default is to not use a proxy server and connect directly to the repository servers.
+apt__https_proxy_url: ''
 
 # .. envvar:: apt__proxy_bypass_for_bugs_debian_org
 #

--- a/docs/scripts/upgrade-from-v0.2.x-to-v0.3.x
+++ b/docs/scripts/upgrade-from-v0.2.x-to-v0.3.x
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Upgrade inventory variables for migration from debops.docker v0.1.x to v0.2.x.
+# Upgrade inventory variables for migration from debops.apt v0.1.x to v0.2.x.
 # The script is idempotent.
 
 git ls-files -z | xargs --null -I '{}' find '{}' -type f -print0 \

--- a/docs/scripts/upgrade-from-v0.2.x-to-v0.3.x
+++ b/docs/scripts/upgrade-from-v0.2.x-to-v0.3.x
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Upgrade inventory variables for migration from debops.docker v0.1.x to v0.2.x.
+# The script is idempotent.
+
+git ls-files -z | xargs --null -I '{}' find '{}' -type f -print0 \
+    | xargs --null sed --in-place --regexp-extended '
+        s/apt__proxy_url:(.*)http:(.*)/apt__http_proxy_url:\1http:\2/g;
+        s/apt__proxy_url:(.*)https:(.*)/apt__https_proxy_url:\1https:\2/g;
+    '

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,13 +7,19 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  when: (apt__enabled|d() | bool) and ((apt__proxy_url is defined and apt__proxy_url is string and apt__proxy_url) or apt__proxy_bypass_for_bugs_debian_org)
+  when: ((apt__enabled|d() | bool) and
+        ((apt__http_proxy_url is defined and apt__http_proxy_url is string and apt__http_proxy_url) or
+        (apt__https_proxy_url is defined and apt__https_proxy_url is string and apt__https_proxy_url) or 
+        apt__proxy_bypass_for_bugs_debian_org))
 
 - name: Configure APT to not use a proxy server
   file:
     path: '/etc/apt/apt.conf.d/000apt-cacher-ng-proxy'
     state: 'absent'
-  when: (apt__enabled|d() | bool) and not ((apt__proxy_url is defined and apt__proxy_url is string and apt__proxy_url) or apt__proxy_bypass_for_bugs_debian_org)
+  when: ((apt__enabled|d() | bool) and 
+        not ((apt__http_proxy_url is defined and apt__http_proxy_url is string and apt__http_proxy_url) or 
+        (apt__https_proxy_url is defined and apt__https_proxy_url is string and apt__https_proxy_url) or 
+        apt__proxy_bypass_for_bugs_debian_org))
 
 - include: apt.yml
   when: (apt__enabled|d() | bool)

--- a/templates/etc/apt/apt.conf.d/000apt-cacher-ng-proxy.j2
+++ b/templates/etc/apt/apt.conf.d/000apt-cacher-ng-proxy.j2
@@ -4,11 +4,14 @@
 // on the client system in order to use a software repository proxy server like
 // Apt-Cacher NG.
 
-{% if apt__proxy_url | match("http://") %}
-Acquire::http::Proxy "{{ apt__proxy_url }}";
-Acquire::https::Proxy "false";
-{% elif apt__proxy_url | match("https://") %}
+{% if apt__http_proxy_url|d() %}
+Acquire::http::Proxy "{{ apt__http_proxy_url }}";
+{% else %}
 Acquire::http::Proxy "false";
-Acquire::https::Proxy "{{ apt__proxy_url }}";
+{% endif %}
+{% if apt__https_proxy_url|d() %}
+Acquire::https::Proxy "{{ apt__https_proxy_url }}";
+{% else %}
+Acquire::https::Proxy "false";
 {% endif %}
 {{ 'Acquire::http::Proxy::bugs.debian.org "DIRECT";' if (apt__proxy_bypass_for_bugs_debian_org|d() | bool) else '' }}


### PR DESCRIPTION
Through apt__http_proxy_url and apt__https_proxy_url it is now possible
to have both http and https repositories when apt needs to use a proxy
server.