### PR TITLE
Grantma default arch distro repos

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -204,9 +204,11 @@ apt__distribution: '{{ ansible_local.core.distribution
 #
 # The OS release present on the host.
 apt__distribution_release: '{{ ansible_local.core.distribution_release
-                               if (ansible_local|d() and ansible_local.core|d() and
-                                   ansible_local.core.distribution_release|d())
-                               else ansible_distribution_release }}'
+                              if (ansible_local|d() and ansible_local.core|d() and
+                                ansible_local.core.distribution_release|d())
+                            else ansible_lsb.codename
+                              if (ansible_lsb|d() and ansible_lsb.codename|d())
+                            else ansible_distribution_release }}'
 
                                                                    # ]]]
 # .. envvar:: apt__distribution_release_map [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -187,6 +187,8 @@ apt__architecture: '{{ apt__architecture_map[ansible_architecture]
 # used.
 apt__architecture_map:
   'x86_64': 'amd64'
+  'i386':   'i386'
+  'armv7l': 'armhf'
 
                                                                    # ]]]
 # .. envvar:: apt__distribution [[[
@@ -227,9 +229,11 @@ apt__distribution_suite_map:
   'Debian_wheezy':    'oldstable'
   'Debian_jessie':    'stable'
   'Debian_stretch':   'testing'
+  'Debian_sid':       'unstable'
   'Raspbian_wheezy':  'oldstable'
   'Raspbian_jessie':  'stable'
   'Raspbian_stretch': 'testing'
+  'Raspbian_sid':     'unstable'
 
                                                                    # ]]]
 # .. envvar:: apt__distribution_suffix_map [[[
@@ -241,10 +245,11 @@ apt__distribution_suite_map:
 # If the combination of OS distribution and release is not found, the default
 # list of suffixes will be used automatically.
 apt__distribution_suffix_map:
-  'Debian_stable':  [ '', '-updates', '-backports' ]
-  'Debian_testing': [ '', '-updates' ]
-  'Raspbian':       [ '' ]
-  'default':        [ '', '-updates', '-backports' ]
+  'Debian_stable':   [ '', '-updates', '-backports' ]
+  'Debian_testing':  [ '', '-updates' ]
+  'Debian_unstable': [ '' ]
+  'Raspbian':        [ '' ]
+  'default':         [ '', '-updates', '-backports' ]
 
                                                                    # ]]]
 # .. envvar:: apt__distribution_suffixes [[[
@@ -338,11 +343,24 @@ apt__original_sources:
 # source for use through the Ansible inventory. It's structure shouldn't be
 # changed.
 apt__default_sources:
-
-  - comment: '{{ "Official " + apt__distribution + " repositories" }}'
-    Debian:   'http://httpredir.debian.org/debian'
-    Raspbian: 'http://mirrordirector.raspbian.org/raspbian/'
-    Ubuntu:   'http://archive.ubuntu.com/ubuntu'
+  - uri:          'http://httpredir.debian.org/debian'
+    comment:      '{{ "Official " + apt__distribution + " repositories" }}'
+    distribution: 'Debian'
+  - uri:          'http://mirrordirector.raspbian.org/raspbian/'
+    comment:      '{{ "Official " + apt__distribution + " repositories" }}'
+    distribution: 'Raspbian'
+  - uri:          'http://archive.ubuntu.com/ubuntu'
+    comment:      '{{ "Official " + apt__distribution + " repositories" }}'
+    distribution: 'Ubuntu'
+    state:       '{{ "present"
+                     if (apt__architecture in ["amd64", "i386"])
+                     else "absent" }}'
+  - uri: 'http://ports.ubuntu.com/ubuntu-ports'
+    comment: '{{ "Official " + apt__distribution + " Port repositories" }}'
+    distribution: 'Ubuntu'
+    state:       '{{ "present"
+                     if (apt__architecture not in ["amd64", "i386"])
+                     else "absent" }}'
 
                                                                    # ]]]
 # .. envvar:: apt__security_sources [[[


### PR DESCRIPTION
Hi! Have tested the changes to default values.

This adds support to apt__default_sources for Ubuntu ARM repos, as well as Debian stretch/sid support and release autodetection.