### PR TITLE
default add pkg ca-certificates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -106,7 +106,7 @@ apt__autoremove_suggests: False
 # .. envvar:: apt__base_packages [[[
 #
 # Default base packages to install.
-apt__base_packages: [ 'python-apt', 'apt-transport-https' ]
+apt__base_packages: [ 'python-apt', 'apt-transport-https', 'ca-certificates' ]
 
                                                                    # ]]]
 # .. envvar:: apt__packages [[[


### PR DESCRIPTION
an error occurs when downloading the package lists from the repository https.
it is connected with distrust of the certificate on the remote server.

```
E: The repository 'https://apt.dockerproject.org/repo ubuntu-xenial Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```