### PR TITLE
Cleanup template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -221,7 +221,7 @@ Added
 
 - Added support for both http and https repositories in case of internet proxy.
   Moved ``apt__proxy_url`` to ``apt__http_proxy_url`` and added
-  ``apt__https_proxy_url``. [tallandtree]
+  ``apt__https_proxy_url``. [tallandtree_]
 
 Changed
 ~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,12 +21,23 @@ new release.
 
 .. _debops.apt master: https://github.com/debops/ansible-apt/compare/v0.4.4...master
 
+Added
+~~~~~
+
+- Add the Ansible local fact ``default_sources_map`` which contains a
+  dictionary with distribution name as key containing a list of default sources
+  for each distribution. ``default_mirrors`` is equivalent to
+  ``default_sources_map[apt__distribution]``  [ypid_]
+
 Changed
 ~~~~~~~
 
-- Filter the Ansible local facts to only provide the default APT mirrors that
-  are relevant to the current OS distribution. This way the list can be used by
-  other Ansible roles for APT mirror information. [drybjed_]
+- Filter the Ansible local facts ``default_mirrors`` to only provide the
+  default APT mirrors that are relevant to the current OS distribution. This
+  way the list can be used by other Ansible roles for APT mirror information.
+  [drybjed_, ypid_]
+
+- Use debops__tpl_macros.js_ to cleanup redundant code. [ypid_]
 
 
 `debops.apt v0.4.4`_ - 2017-03-24

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,8 +1,8 @@
 debops.apt - Manage APT repositories and keys using Ansible
 
-Copyright (C) 2013-2016 Maciej Delmanowski <drybjed@gmail.com>
-Copyright (C) 2015-2016 Robin Schneider <ypid@riseup.net>
-Copyright (C) 2014-2016 DebOps https://debops.org/
+Copyright (C) 2013-2017 Maciej Delmanowski <drybjed@gmail.com>
+Copyright (C) 2015-2017 Robin Schneider <ypid@riseup.net>
+Copyright (C) 2014-2017 DebOps https://debops.org/
 
 This Ansible role is part of DebOps.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -139,7 +139,6 @@ apt__group_keys: []
 #
 # List of APT GPG keys to configure on specific hosts in Ansible inventory.
 apt__host_keys: []
-
                                                                    # ]]]
                                                                    # ]]]
 # APT repositories [[[
@@ -166,7 +165,6 @@ apt__group_repositories: []
 #
 # List of additional APT repositories for specific hosts in Ansible inventory.
 apt__host_repositories: []
-
                                                                    # ]]]
                                                                    # ]]]
 # Distribution and release detection [[[

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -47,9 +47,9 @@ Ansible tags
 ------------
 
 You can use Ansible ``--tags`` or ``--skip-tags`` parameters to limit what
-tasks are performed during Ansible run. This can be used after host is first
+tasks are performed during Ansible run. This can be used after a host was first
 configured to speed up playbook execution, when you are sure that most of the
-configuration has not been changed.
+configuration is already in the desired state.
 
 Available role tags:
 

--- a/templates/etc/ansible/facts.d/apt.fact.j2
+++ b/templates/etc/ansible/facts.d/apt.fact.j2
@@ -1,35 +1,21 @@
+{% import 'templates/import/debops__tpl_macros.j2' as debops__tpl_macros with context %}
 #!/usr/bin/env python
 
 # {{ ansible_managed }}
 {% set apt__tpl_security_sources = [] %}
-{% for repo in apt__security_sources %}
-{%   if repo.uri|d() %}
-{%     for element in ([ repo.uri ] if repo.uri is string else repo.uri) %}
-{%       set _ = apt__tpl_security_sources.append(element) %}
-{%     endfor %}
-{%   endif %}
-{%   if repo.uris|d() %}
-{%     for element in ([ repo.uris ] if repo.uris is string else repo.uris) %}
-{%       set _ = apt__tpl_security_sources.append(element) %}
-{%     endfor %}
-{%   endif %}
-{% endfor %}
 {% set apt__tpl_default_sources = [] %}
+{% set apt__tpl_default_sources_map = {} %}
+{% set apt__tpl_source_distributions = {} %}
+{% for repo in apt__security_sources %}
+{%   set _ = apt__tpl_security_sources.extend(debops__tpl_macros.flattened(repo.uri, repo.uris) | from_json) %}
+{% endfor %}
 {% for repo in apt__default_sources %}
-{%   if repo.uri|d() and repo.state|d('present') != 'absent' and (repo.distribution|d() and repo.distribution == apt__distribution) %}
-{%     for element in ([ repo.uri ] if repo.uri is string else repo.uri) %}
-{%       set _ = apt__tpl_default_sources.append(element) %}
-{%     endfor %}
+{%   set repo_uris = (debops__tpl_macros.flattened(repo.uri, repo.uris) | from_json) %}
+{%   if repo.distribution|d() == apt__distribution %}
+{%     set _ = apt__tpl_default_sources.extend(repo_uris) %}
 {%   endif %}
-{%   if repo.uris|d() and repo.state|d('present') != 'absent' and (repo.distribution|d() and repo.distribution == apt__distribution) %}
-{%     for element in ([ repo.uris ] if repo.uris is string else repo.uris) %}
-{%       set _ = apt__tpl_default_sources.append(element) %}
-{%     endfor %}
-{%   endif %}
-{%   if apt__distribution in repo.keys() %}
-{%     for element in ([ repo[apt__distribution] ] if repo[apt__distribution] is string else repo[apt__distribution]) %}
-{%       set _ = apt__tpl_default_sources.append(element) %}
-{%     endfor %}
+{%   if repo.distribution|d() %}
+{%     set _ = apt__tpl_default_sources_map.update({ repo.distribution: ((apt__tpl_default_sources_map[repo.distribution]|d([])) + repo_uris) }) %}
 {%   endif %}
 {% endfor %}
 
@@ -40,12 +26,14 @@ import os
 
 security_sources = loads('''{{ apt__tpl_security_sources | to_nice_json }}''')
 
-default_sources = loads('''{{ apt__tpl_default_sources | to_nice_json }}''')
-
-output = loads('''{
-    "configured": {{ (ansible_local.apt.configured if (ansible_local|d() and ansible_local.apt|d() and ansible_local.apt.configured|d()) else False) | bool | lower }},
-    "enabled": {{ apt__enabled | bool | lower }}
-}''')
+output = loads('''{{ ({
+    "enabled": apt__enabled,
+    "configured": (ansible_local.apt.configured
+                   if (ansible_local|d() and ansible_local.apt|d() and ansible_local.apt.configured|d())
+                   else False),
+    "default_mirrors": apt__tpl_default_sources,
+    "default_sources_map": apt__tpl_default_sources_map,
+    }) | to_nice_json }}''')
 
 apt_sources_list = [ '/etc/apt/sources.list.dpkg-divert', '/etc/apt/sources.list' ]
 
@@ -104,10 +92,9 @@ except Exception:
     pass
 
 output.update({
-    "default_mirrors": default_sources,
     "nonfree": apt_nonfree,
     "original_mirrors_deb": source_deb,
-    "original_mirrors_deb_src": source_deb_src
+    "original_mirrors_deb_src": source_deb_src,
 })
 
 print(dumps(output, sort_keys=True, indent=2))

--- a/templates/etc/ansible/facts.d/apt.fact.j2
+++ b/templates/etc/ansible/facts.d/apt.fact.j2
@@ -14,7 +14,7 @@
 {%   if repo.distribution|d() == apt__distribution %}
 {%     set _ = apt__tpl_default_sources.extend(repo_uris) %}
 {%   endif %}
-{%   if repo.distribution|d() %}
+{%   if repo.distribution|d() and (repo.state|d("present") == "present") %}
 {%     set _ = apt__tpl_default_sources_map.update({ repo.distribution: ((apt__tpl_default_sources_map[repo.distribution]|d([])) + repo_uris) }) %}
 {%   endif %}
 {% endfor %}

--- a/templates/etc/ansible/facts.d/apt.fact.j2
+++ b/templates/etc/ansible/facts.d/apt.fact.j2
@@ -33,7 +33,8 @@ output = loads('''{{ ({
                    else False),
     "default_mirrors": apt__tpl_default_sources,
     "default_sources_map": apt__tpl_default_sources_map,
-    }) | to_nice_json }}''')
+    }) | to_nice_json | regex_replace("[ \\t\\r\\f\\v]+(\\n|$)", "\\1") }}''')
+{# regex_replace is a workaround for https://github.com/ansible/ansible/issues/23078 #}
 
 apt_sources_list = [ '/etc/apt/sources.list.dpkg-divert', '/etc/apt/sources.list' ]
 

--- a/templates/import/debops__tpl_macros.j2
+++ b/templates/import/debops__tpl_macros.j2
@@ -1,0 +1,192 @@
+{# vim: foldmarker=[[[,]]]:foldmethod=marker
+# Commonly used set of macros in DebOps.
+# It can be included in repositories as needed.
+# Changes to this file should go upstream: https://github.com/debops/debops-playbooks/blob/master/templates/debops__tpl_macros.j2
+#
+# Copyright [[[
+# =============
+#
+# Copyright (C) 2014-2017 Maciej Delmanowski <drybjed@drybjed.net>
+# Copyright (C) 2015-2017 Robin Schneider <ypid@riseup.net>
+# Copyright (C) 2014-2017 DebOps https://debops.org/
+#
+# This file is part of DebOps.
+#
+# DebOps is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# DebOps is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with DebOps. If not, see https://www.gnu.org/licenses/.
+#
+# ]]]
+#
+# Usage [[[
+# =========
+#
+# Copy the template file to `./templates/import/debops__tpl_macros.j2` of your
+# role and import it from there into various other templates or even use it
+# in {{ lookup("template", ...) }}.
+#
+# Make sure to retain the filename of this file so that automatic updates of
+# this file can be implemented.
+#
+# To use the macros in your own template, this file needs to be included like so:
+#
+# {% import 'templates/import/debops__tpl_macros.j2' as debops__tpl_macros with context %}
+#
+# Then you can start using the macros like this:
+#
+# {{ debops__tpl_macros.indent(some_content, 4) }}
+#
+# ]]] #}
+
+{% macro get_yaml_list_for_elem(list_or_elem) %}{# [[[ #}
+{{ ([ list_or_elem ]
+    if (list_or_elem is string or list_or_elem in [True, False])
+    else (list_or_elem|list)) | to_nice_yaml }}
+{% endmacro %}{# ]]] #}
+
+{% macro get_realm_yaml_list(domains, fallback_realm) %}{# [[[ #}
+{% set custom_realm_list = [] %}
+{% if domains and (ansible_local|d() and ansible_local.pki|d() and ansible_local.pki.known_realms|d()) %}
+{%   for domain in (get_yaml_list_for_elem(domains) | from_yaml) %}
+{%     if domain in ansible_local.pki.known_realms %}
+{%       set _ = custom_realm_list.append(domain) %}
+{%     elif (domain.split('.')[1:] | join('.')) in ansible_local.pki.known_realms %}
+{%       set _ = custom_realm_list.append(domain.split('.')[1:] | join('.')) %}
+{%     endif %}
+{%   endfor %}
+{% endif %}
+{% if custom_realm_list|length == 0 %}
+{%   set _ = custom_realm_list.append(fallback_realm) %}
+{% endif %}
+{{ custom_realm_list | to_nice_yaml }}
+{% endmacro %}{# ]]] #}
+
+{% macro get_apache_version() %}{# [[[ #}
+{{ ansible_local.apache.version
+   if (ansible_local|d() and ansible_local.apache|d() and
+       ansible_local.apache.version|d())
+   else "2.4.0" -}}
+{% endmacro %}{# ]]] #}
+
+{% macro get_apache_min_version() %}{# [[[ #}
+{{ ansible_local.apache.min_version
+   if (ansible_local|d() and ansible_local.apache|d() and
+       ansible_local.apache.min_version|d())
+   else "2.4.0" -}}
+{% endmacro %}{# ]]] #}
+
+{% macro get_openssl_version() %}{# [[[ #}
+{{ ansible_local.pki.openssl_version
+   if (ansible_local|d() and ansible_local.pki|d() and
+       ansible_local.pki.openssl_version|d())
+   else "0.0.0" }}
+{% endmacro %}{# ]]] #}
+
+{% macro get_gnutls_version() %}{# [[[ #}
+{{ ansible_local.pki.gnutls_version
+   if (ansible_local|d() and ansible_local.pki|d() and
+       ansible_local.pki.gnutls_version|d())
+   else "0.0.0" }}
+{% endmacro %}{# ]]] #}
+
+{% macro indent(content, width=4, indentfirst=False) %}{# [[[ #}
+{# Fixed version of the `indent` filter which does not insert trailing spaces on empty lines.
+## Note that you can not use this macro like a filter but have to use it like a regular macro.
+## Example: {{ debops__tpl_macros.indent(some_content, 4) }}
+##
+## Python re.sub seems to default to re.MULTILINE in Ansible.
+#}
+{{ content | indent(width, indentfirst) | regex_replace("[ \\t\\r\\f\\v]+(\\n|$)", "\\1") -}}
+{% endmacro %}{# ]]] #}
+
+{% macro merge_dict(current_dict, to_merge_dict, dict_key='name') %}{# [[[ #}
+{%   set merged_dict = current_dict %}
+{%   if to_merge_dict %}
+{%     if to_merge_dict is mapping %}
+{%       for dict_name in to_merge_dict.keys() | sort %}
+{%         if to_merge_dict[dict_name][dict_key]|d() %}
+{%           set _ = merged_dict.update({to_merge_dict[dict_name][dict_key]:(current_dict[to_merge_dict[dict_name][dict_key]]|d({}) | combine(to_merge_dict[dict_name], recursive=True))}) %}
+{%         elif to_merge_dict[dict_name][dict_key] is undefined %}
+{%           set _ = merged_dict.update({dict_name:(current_dict[dict_name]|d({}) | combine(to_merge_dict[dict_name], recursive=True))}) %}
+{%         endif %}
+{%       endfor %}
+{%     elif to_merge_dict is not string and to_merge_dict is not mapping %}
+{%       set flattened_dict = lookup("flattened", to_merge_dict) %}
+{%       for element in ([ flattened_dict ] if flattened_dict is mapping else flattened_dict) %}
+{%         if element[dict_key]|d() %}
+{%           set _ = merged_dict.update({element[dict_key]:(current_dict[element[dict_key]]|d({}) | combine(element, recursive=True))}) %}
+{%         endif %}
+{%       endfor %}
+{%     endif %}
+{%   endif %}
+{{ merged_dict | to_json }}
+{% endmacro %}{# ]]] #}
+
+{% macro flattened() %}{# [[[ #}
+{# This macro does what the flattened lookup from Ansible fails to do in Jinja templates as of Ansible 2.2.
+## All macro arguments are flattened into one "flat" list.
+## Uses a less known feature of Jinja for using the *args and *kwargs syntax as known from
+## Python. Even if the macro does not declare any arguments, it will happyily
+## flatten any non-key-value arguments you provide.
+## Additional key-value arguments can be used to influence the behavoir of the macro.
+## The macro uses recursion to flatten nested lists.
+## Ref: https://stackoverflow.com/questions/13944751/args-kwargs-in-jinja2-macros
+## Usage:
+##
+## {{ debops__tpl_macros.flattened(['list1', 55, ["deeplist1", "deeplist elem", True, False, undefined], {'mapping': True}], 'raw1', 22, True, False) }}
+## → ["list1", 55, "deeplist1", "deeplist elem", true, false, "raw1", 22, true, false]
+##
+## {{ debops__tpl_macros.flattened(['list1', 55, ["deeplist1", "deeplist elem", True, False, undefined], {'mapping': True}], 'raw1', 22, True, False, filter_undef=False) }}
+## → ["list1", 55, "deeplist1", "deeplist elem", true, false, null, "raw1", 22, true, false]
+##
+## {{ debops__tpl_macros.flattened(['list1', 55, ["deeplist1", "deeplist elem", True, False, undefined], {'mapping': True}], 'raw1', 22, True, False, filter_mapping=False) }}
+## → ["list1", 55, "deeplist1", "deeplist elem", true, false, {"mapping": true}, "raw1", 22, true, false]
+##
+## Ansible versions tested with: 2.1, 2.2
+## Jinja versions tested with: 2.8.1
+#}
+{% set filter_undef = kwargs.filter_undef|d(True) | bool %}
+{% set filter_mapping = kwargs.filter_mapping|d(True) | bool %}
+{# The following options are planned but currently don’t work: #}
+{% set append_mapping_keys = kwargs.append_mapping_keys|d(False) | bool %}
+{% set append_mapping_values = kwargs.append_mapping_values|d(False) | bool %}
+{#
+{{ "filter_undef:" + (filter_undef | string) }}
+{{ "filter_mapping:" + (filter_mapping | string) }}
+{{ "varargs:" + (varargs | string) }}
+#}
+{% set elem_flattened = [] %}
+{% for arg in varargs %}
+{#
+{{ "arg: " + (arg | string) }}
+#}
+{%   if filter_undef and (arg is undefined) %}
+{#     Filter out. #}
+{%   elif append_mapping_keys and (arg is mapping) %}
+{#     Does not work as of Jinja 2.8? #}
+{%     set _ = elem_flattened.extend(flattened(arg.keys(), filter_undef=filter_undef, filter_mapping=filter_mapping) | from_json) %}
+{%   elif append_mapping_values and (arg is mapping) %}
+{#     Does not work as of Jinja 2.8? #}
+{%     set _ = elem_flattened.extend(flattened(arg.values(), filter_undef=filter_undef, filter_mapping=filter_mapping) | from_json) %}
+{%   elif filter_mapping and (arg is mapping) %}
+{#     Filter out. #}
+{%   elif (arg is undefined) %}
+{%     set _ = elem_flattened.append(None) %}
+{%   elif (arg is string) or (arg is number) or (arg is sameas True) or (arg is sameas False) or (arg is mapping) %}
+{%     set _ = elem_flattened.append(arg) %}
+{%   elif (arg is iterable) %}
+{%     for element in arg %}
+{%       set _ = elem_flattened.extend(flattened(element, filter_undef=filter_undef, filter_mapping=filter_mapping) | from_json) %}
+{%     endfor %}
+{%   endif %}
+{% endfor %}
+{{ elem_flattened | to_json }}
+{% endmacro %}{# ]]] #}


### PR DESCRIPTION
> > Redundancy ? :wink:
>
> Ups. Yeah, I guess. The role is not tagged yet, so there's still time to fix that.

Ref: https://github.com/debops/ansible-apt/pull/87#discussion_r108154006

Doing that then. I don’t think we should accept such redundancy in the DebOps codebase. That just makes extending/maintenance more difficult and looks ugly. Or if we need to do this then at least do it in one place (`debops__tpl_macros.j2 `). We can do better. DebOps should be unicorns all the way :wink:

@drybjed Refer to "macro flattened()" :wink: I will tested that macro also with other roles. You can wait with merging. I will update this in other roles, test it and open few more PR. It can be merged all at once when it does not break anywhere.

Ref: https://github.com/debops/debops-playbooks/pull/351