### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,7 @@ Changed
 
 - Use debops__tpl_macros.js_ to cleanup redundant code. [ypid_]
 
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 `debops.apt v0.4.4`_ - 2017-03-24
 ---------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,7 +39,8 @@ Changed
 
 - Use debops__tpl_macros.js_ to cleanup redundant code. [ypid_]
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 `debops.apt v0.4.4`_ - 2017-03-24
 ---------------------------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   author: 'Maciej Delmanowski, Robin Schneider'
   description: 'Manage APT repositories and keys'
   license: 'GPL-3.0'
-  min_ansible_version: '2.0.0'
+  min_ansible_version: '2.2.0'
 
   platforms:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,7 @@
   shell: dpkg-divert --list '/etc/apt/*.dpkg-divert' | awk '{print $NF}'
   register: apt__register_diversions
   when: apt__enabled|bool
-  always_run: True
+  check_mode: no
   changed_when: False
 
 - name: Divert original /etc/apt/sources.list

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,7 @@
   shell: dpkg-divert --list '/etc/apt/*.dpkg-divert' | awk '{print $NF}'
   register: apt__register_diversions
   when: apt__enabled|bool
-  check_mode: no
+  check_mode: False
   changed_when: False
 
 - name: Divert original /etc/apt/sources.list


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.